### PR TITLE
Fixed Route Metadata

### DIFF
--- a/src/assets/route-data.json
+++ b/src/assets/route-data.json
@@ -52,6 +52,7 @@
     "DD": "Diag-to-Diag",
     "MX": "Med Express",
     "NE": "Northeast Shuttle",
+    "NES": "Northeast Shuttle",
     "NW": "Northwood",
     "NX": "Northwood Express",
     "OS": "Oxford Shuttle",

--- a/src/assets/route-data.json
+++ b/src/assets/route-data.json
@@ -60,6 +60,6 @@
     "WX": "Wall Street Express"
   },
   "metadata": {
-    "version": 3
+    "version": 4
   }
 }

--- a/src/v3.ts
+++ b/src/v3.ts
@@ -188,7 +188,7 @@ router.get('/getRouteInformation', (req, res) => {
 });
 
 router.get('/getUpdateNotes', (req, res) => {
-    res.send({message: "- ·Support new routes\n- ·Added route names to arrivals at shared stops\n- ·General improvements", version: "6"});
+    res.send({message: "- ·Fixed Northeast Shuttle Icons\n- ·Working bus icons for Northeast Shuttle\n- ·General improvements", version: "7"});
 });
 
 router.get('/getBusPredictions/:busId', (req, res) => {


### PR DESCRIPTION
Added NES to routeIdToName in route-data.json file so app will now display correct icon for Northeast Shuttle buses